### PR TITLE
eSpeak support

### DIFF
--- a/doc_generator/engine.rst
+++ b/doc_generator/engine.rst
@@ -223,11 +223,11 @@ Listening for events
 
     import pyttsx3
     def onStart(name):
-        print 'starting', name
+        print('starting', name)
     def onWord(name, location, length):
-        print 'word', name, location, length
+        print('word', name, location, length)
     def onEnd(name, completed):
-        print 'finishing', name, completed
+        print('finishing', name, completed)
     engine = pyttsx3.init()
     engine.connect('started-utterance', onStart)
     engine.connect('started-word', onWord)
@@ -242,7 +242,7 @@ Interrupting an utterance
 
     import pyttsx3
     def onWord(name, location, length):
-        print 'word', name, location, length
+        print('word', name, location, length)
         if location > 10:
             engine.stop()
     engine = pyttsx3.init()
@@ -291,11 +291,11 @@ Running a driver event loop
 
     engine = pyttsx3.init()
     def onStart(name):
-        print 'starting', name
+      print('starting', name)
     def onWord(name, location, length):
-        print 'word', name, location, length
+        print('word', name, location, length)
     def onEnd(name, completed):
-        print 'finishing', name, completed
+        print('finishing', name, completed)
         if name == 'fox':
             engine.say('What a lazy dog!', 'dog')
         elif name == 'dog':

--- a/pyttsx3/driver.py
+++ b/pyttsx3/driver.py
@@ -104,7 +104,7 @@ class DriverProxy(object):
         @param kwargs: Arbitrary keyword arguments
         @type kwargs: dict
         """
-        kwargs['name'] = self._name
+        kwargs['name'] = kwargs.get('name', self._name)
         self._engine._notify(topic, **kwargs)
 
     def setBusy(self, busy):

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -41,7 +41,7 @@ def load_library():
             dll = cdll.LoadLibrary(path)
             return True
         except Exception as e:
-            print(f"Failed to load: {path}, Exception: {str(e)}")
+            return False
     return False
 
 try:

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -18,81 +18,38 @@ def cfunc(name, dll, result, *args):
 
 dll = None
 
-def load_macos_espeak():
+def load_library():
     global dll
-    try:
-        dll = cdll.LoadLibrary('/usr/local/lib/libespeak.dylib')
-    except Exception:
-        return False
-    else:
-        return True
-
+    paths = [
+        # macOS paths
+        '/usr/local/lib/libespeak-ng.1.dylib',
+        '/usr/local/lib/libespeak.dylib',
+        
+        # Linux paths
+        'libespeak-ng.so.1',
+        '/usr/local/lib/libespeak-ng.so.1',
+        'libespeak.so.1',
+        
+        # Windows paths
+        'libespeak-ng.dll',
+        'C:\\Program Files\\eSpeak NG\\libespeak-ng.dll',
+        'C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll'
+    ]
     
-def load_linux_ep():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('libespeak.so.1')
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def load_linux_epng():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('libespeak-ng.so.1')
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def load_linux_epng2():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('/usr/local/lib/libespeak-ng.so.1')
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def load_windows_epng1():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('libespeak-ng.dll')
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def load_windows_epng2():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('C:\\Program Files\\eSpeak NG\\libespeak-ng.dll')
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def load_windows_epng3():
-    global dll
-    try:
-        dll = cdll.LoadLibrary('C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll')
-    except Exception:
-        return False
-    else:
-        return True
-
+    for path in paths:
+        try:
+            dll = cdll.LoadLibrary(path)
+            return True
+        except Exception as e:
+            print(f"Failed to load: {path}, Exception: {str(e)}")
+    return False
 
 try:
-    load_macos_espeak() or load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    if not load_library():
+        raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
-    raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")
+    raise
 
 # constants and such from speak_lib.h
 

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -89,7 +89,8 @@ def load_windows_epng3():
 
 
 try:
-    load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    load_macos_espeak() or load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    print(f"Loaded {dll}")
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
     raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -32,8 +32,9 @@ def load_library():
         
         # Windows paths
         'libespeak-ng.dll',
-        'C:\\Program Files\\eSpeak NG\\libespeak-ng.dll',
-        'C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll'
+        # Windows paths
+        r'C:\Program Files\eSpeak NG\libespeak-ng.dll',
+        r'C:\Program Files (x86)\eSpeak NG\libespeak-ng.dll'
     ]
     
     for path in paths:

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -89,7 +89,7 @@ def load_windows_epng3():
 
 
 try:
-    load_macos_espeak() or load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    load_macos_espeak() or load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
     raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -18,7 +18,16 @@ def cfunc(name, dll, result, *args):
 
 dll = None
 
+def load_macos_espeak():
+    global dll
+    try:
+        dll = cdll.LoadLibrary('/usr/local/lib/libespeak.dylib')
+    except Exception:
+        return False
+    else:
+        return True
 
+    
 def load_linux_ep():
     global dll
     try:
@@ -80,7 +89,7 @@ def load_windows_epng3():
 
 
 try:
-    load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
     raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -90,7 +90,6 @@ def load_windows_epng3():
 
 try:
     load_macos_espeak() or load_linux_epng2() or load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
-    print(f"Loaded {dll}")
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
     raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -31,8 +31,6 @@ def load_library():
         'libespeak.so.1',
         
         # Windows paths
-        'libespeak-ng.dll',
-        # Windows paths
         r'C:\Program Files\eSpeak NG\libespeak-ng.dll',
         r'C:\Program Files (x86)\eSpeak NG\libespeak-ng.dll'
     ]
@@ -41,17 +39,16 @@ def load_library():
         try:
             dll = cdll.LoadLibrary(path)
             return True
-        except Exception as e:
-            return False
+        except Exception:
+            continue  # Try the next path
     return False
 
 try:
     if not load_library():
         raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")
 except Exception as exp:
-    print("Exception: " + str(exp) + "\n")
     raise
-
+    
 # constants and such from speak_lib.h
 
 EVENT_LIST_TERMINATED = 0

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -23,7 +23,6 @@ class EspeakDriver(object):
     _defaultVoice = ''
 
     def __init__(self, proxy):
-        print("[EspeakDriver.__init__] Initializing eSpeak Driver")
         if not EspeakDriver._moduleInitialized:
             # espeak cannot initialize more than once per process and has
             # issues when terminating from python (assert error on close)
@@ -119,40 +118,31 @@ class EspeakDriver(object):
             raise KeyError('unknown property %s' % name)
 
     def save_to_file(self, text, filename):
-        print("[EspeakDriver.save to file] synth to file.. ")
         code = self.numerise(filename)
         _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8, user_data=code)
 
     def _start_synthesis(self, text):
-        print(f"[EspeakDriver._start_synthesis] Starting synthesis for text: {text}")
         self._proxy.setBusy(True)
         self._proxy.notify('started-utterance')
         self._speaking = True
         self._data_buffer = b''  # Ensure buffer is cleared before starting
         try:
-            print(f"[EspeakDriver._start_synthesis] Calling eSpeak with text: {text}")
             _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8)
         except Exception as e:
-            print(f"[EspeakDriver._start_synthesis] Error during speak: {e}")
             self._proxy.setBusy(False)
             self._proxy.notify('error', exception=e)
             raise
-        finally:
-            print("[EspeakDriver._start_synthesis] Finally block executed")
 
 
     def _onSynth(self, wav, numsamples, events):
-        print("[EspeakDriver._onSynth] Called")
         i = 0
         while True:
             event = events[i]
-            print(f"[EspeakDriver._onSynth] Event type: {event.type}, Position: {event.text_position}, Length: {event.length}")
             if event.type == _espeak.EVENT_LIST_TERMINATED:
                 break
             if event.type == _espeak.EVENT_WORD:
-                self._proxy.notify('started-word', location=event.text_position - 1, length=event.length)
+                self._proxy.notify('started-word', location=event.text_position, length=event.length)
             elif event.type == _espeak.EVENT_END:
-                print("[EspeakDriver._onSynth] EVENT_END")
                 stream = NamedTemporaryFile(delete=False, suffix='.wav')
     
                 try:
@@ -167,24 +157,14 @@ class EspeakDriver(object):
                         os.system(f'ffmpeg -y -i {stream.name} {self.decode_numeric(event.user_data)} -loglevel quiet')
                     else:
                         if platform.system() == 'Darwin':  # macOS
-                            print(f"[EspeakDriver._onSynth] Playing sound on macOS... {stream.name}")
                             try:
                                 result = subprocess.run(['afplay', stream.name], check=True, capture_output=True, text=True)
-                                print(f"[EspeakDriver._onSynth] afplay result: {result.returncode}")
-                                print(f"[EspeakDriver._onSynth] afplay stdout: {result.stdout}")
-                                print(f"[EspeakDriver._onSynth] afplay stderr: {result.stderr}")
-                                if result.returncode == 0:
-                                    print(f"[EspeakDriver._onSynth] afplay completed successfully")
-                                else:
-                                    print(f"[EspeakDriver._onSynth] afplay failed with return code {result.returncode}")
                             except subprocess.CalledProcessError as e:
-                                print(f"[EspeakDriver._onSynth] afplay failed with error: {e}")
+                                raise RuntimeError(f"[EspeakDriver._onSynth] Mac afplay failed with error: {e}")
                         elif platform.system() == 'Linux':
                             os.system(f'aplay {stream.name} -q')
                         elif platform.system() == 'Windows':
-                            print(f"[EspeakDriver._onSynth] Playing sound on Windows... {stream.name}")
                             winsound.PlaySound(stream.name, winsound.SND_FILENAME)  # Blocking playback
-                            print(f"[EspeakDriver._onSynth] Finished playing sound on Windows... {stream.name}")
     
                 except Exception as e:
                     raise RuntimeError(f"Error during playback: {e}")
@@ -206,6 +186,7 @@ class EspeakDriver(object):
         if numsamples > 0:
             self._data_buffer += ctypes.string_at(wav, numsamples * ctypes.sizeof(ctypes.c_short))
         return 0
+
     
     def endLoop(self):
         self._looping = False
@@ -233,8 +214,6 @@ class EspeakDriver(object):
             self._proxy.notify('finished-utterance', completed=False)
             self._proxy.setBusy(False)
             self.endLoop()
-
-
 
     def say(self, text):
         self._text_to_say = text

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -183,7 +183,6 @@ class EspeakDriver(object):
                     elif platform.system() == 'Linux':
                         os.system(f'aplay {stream.name} -q')
                     elif platform.system() == 'Windows':
-                        print(f"Playing sound on Windows... {stream.name}")
                         winsound.PlaySound(stream.name, winsound.SND_FILENAME)
                     else:
                         raise RuntimeError("Unsupported operating system for audio playback")

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -3,6 +3,7 @@ import wave
 import platform
 import ctypes
 import time
+import subprocess
 from tempfile import NamedTemporaryFile
 if platform.system() == 'Windows':
     import winsound
@@ -22,25 +23,28 @@ class EspeakDriver(object):
     _defaultVoice = ''
 
     def __init__(self, proxy):
+        print("[EspeakDriver.__init__] Initializing eSpeak Driver")
         if not EspeakDriver._moduleInitialized:
             # espeak cannot initialize more than once per process and has
             # issues when terminating from python (assert error on close)
-            # so just keep it alive and init once
+            # so just keep it alive and init once        
             rate = _espeak.Initialize(_espeak.AUDIO_OUTPUT_RETRIEVAL, 1000)
             if rate == -1:
                 raise RuntimeError('could not initialize espeak')
             EspeakDriver._defaultVoice = 'default'
             EspeakDriver._moduleInitialized = True
+        self._proxy = proxy
+        self._looping = False
+        self._stopping = False
+        self._speaking = False
+        self._text_to_say = None
+        self._data_buffer = b''
+        self._numerise_buffer = []
+
         _espeak.SetSynthCallback(self._onSynth)
-        # make sure all props reset
         self.setProperty('voice', EspeakDriver._defaultVoice)
         self.setProperty('rate', 200)
         self.setProperty('volume', 1.0)
-        self._proxy = proxy
-        self._looping = True
-        self._stopping = False
-        self._data_buffer = b''
-        self._numerise_buffer = []
 
     def numerise(self, data):
         self._numerise_buffer.append(data)
@@ -53,14 +57,10 @@ class EspeakDriver(object):
     def destroy():
         _espeak.SetSynthCallback(None)
 
-    def say(self, text):
-        self._proxy.setBusy(True)
-        self._proxy.notify('started-utterance')
-        _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8)
-
     def stop(self):
         if _espeak.IsPlaying():
             self._stopping = True
+            _espeak.Cancel()
 
     @staticmethod
     def getProperty(name: str):
@@ -118,54 +118,41 @@ class EspeakDriver(object):
         else:
             raise KeyError('unknown property %s' % name)
 
-    def startLoop(self):
-        first = True
-        self._stopping = False
-        self._looping = True
-        while self._looping:
-            if first:
-                # kick the queue
-                self._proxy.setBusy(False)
-                first = False
-            if self._stopping and self._looping:
-                # have to do the cancel on the main thread, not inside the
-                # callback else deadlock
-                _espeak.Cancel()
-                self._stopping = False
-                self._proxy.notify('finished-utterance', completed=False)
-                self._proxy.setBusy(False)
-            time.sleep(0.01)
-
     def save_to_file(self, text, filename):
+        print("[EspeakDriver.save to file] synth to file.. ")
         code = self.numerise(filename)
         _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8, user_data=code)
 
-    def endLoop(self):
-        self._looping = False
+    def _start_synthesis(self, text):
+        print(f"[EspeakDriver._start_synthesis] Starting synthesis for text: {text}")
+        self._proxy.setBusy(True)
+        self._proxy.notify('started-utterance')
+        self._speaking = True
+        self._data_buffer = b''  # Ensure buffer is cleared before starting
+        try:
+            print(f"[EspeakDriver._start_synthesis] Calling eSpeak with text: {text}")
+            _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8)
+        except Exception as e:
+            print(f"[EspeakDriver._start_synthesis] Error during speak: {e}")
+            self._proxy.setBusy(False)
+            self._proxy.notify('error', exception=e)
+            raise
+        finally:
+            print("[EspeakDriver._start_synthesis] Finally block executed")
 
-    def iterate(self):
-        self._proxy.setBusy(False)
-        while 1:
-            if self._stopping:
-                # have to do the cancel on the main thread, not inside the
-                # callback else deadlock
-                _espeak.Cancel()
-                self._stopping = False
-                self._proxy.notify('finished-utterance', completed=False)
-                self._proxy.setBusy(False)
-            yield
 
     def _onSynth(self, wav, numsamples, events):
+        print("[EspeakDriver._onSynth] Called")
         i = 0
         while True:
             event = events[i]
+            print(f"[EspeakDriver._onSynth] Event type: {event.type}, Position: {event.text_position}, Length: {event.length}")
             if event.type == _espeak.EVENT_LIST_TERMINATED:
                 break
             if event.type == _espeak.EVENT_WORD:
-                self._proxy.notify('started-word',
-                                   location=event.text_position - 1,
-                                   length=event.length)
-            elif event.type == _espeak.EVENT_MSG_TERMINATED:
+                self._proxy.notify('started-word', location=event.text_position - 1, length=event.length)
+            elif event.type == _espeak.EVENT_END:
+                print("[EspeakDriver._onSynth] EVENT_END")
                 stream = NamedTemporaryFile(delete=False, suffix='.wav')
     
                 try:
@@ -174,34 +161,80 @@ class EspeakDriver(object):
                         f.setsampwidth(2)
                         f.setframerate(22050.0)
                         f.writeframes(self._data_buffer)
+                    self._data_buffer = b''
     
                     if event.user_data:
-                        os.system(
-                            f'ffmpeg -y -i {stream.name} {self.decode_numeric(event.user_data)} -loglevel quiet')
+                        os.system(f'ffmpeg -y -i {stream.name} {self.decode_numeric(event.user_data)} -loglevel quiet')
                     else:
                         if platform.system() == 'Darwin':  # macOS
-                            os.system(f'afplay {stream.name}')
+                            print(f"[EspeakDriver._onSynth] Playing sound on macOS... {stream.name}")
+                            try:
+                                result = subprocess.run(['afplay', stream.name], check=True, capture_output=True, text=True)
+                                print(f"[EspeakDriver._onSynth] afplay result: {result.returncode}")
+                                print(f"[EspeakDriver._onSynth] afplay stdout: {result.stdout}")
+                                print(f"[EspeakDriver._onSynth] afplay stderr: {result.stderr}")
+                                if result.returncode == 0:
+                                    print(f"[EspeakDriver._onSynth] afplay completed successfully")
+                                else:
+                                    print(f"[EspeakDriver._onSynth] afplay failed with return code {result.returncode}")
+                            except subprocess.CalledProcessError as e:
+                                print(f"[EspeakDriver._onSynth] afplay failed with error: {e}")
                         elif platform.system() == 'Linux':
                             os.system(f'aplay {stream.name} -q')
                         elif platform.system() == 'Windows':
-                            winsound.PlaySound(stream.name, winsound.SND_FILENAME)
-                        else:
-                            raise RuntimeError("Unsupported operating system for audio playback")
+                            print(f"[EspeakDriver._onSynth] Playing sound on Windows... {stream.name}")
+                            winsound.PlaySound(stream.name, winsound.SND_FILENAME)  # Blocking playback
+                            print(f"[EspeakDriver._onSynth] Finished playing sound on Windows... {stream.name}")
     
                 except Exception as e:
                     raise RuntimeError(f"Error during playback: {e}")
-                
+    
                 finally:
                     try:
+                        stream.close()  # Ensure the file is closed
                         os.remove(stream.name)
                     except Exception as e:
                         raise RuntimeError(f"Error deleting temporary WAV file: {e}")
     
-                self._data_buffer = b''
                 self._proxy.notify('finished-utterance', completed=True)
                 self._proxy.setBusy(False)
+                self.endLoop()  # End the loop here
+                break  # Exit the loop after handling the termination event
+    
             i += 1
     
         if numsamples > 0:
             self._data_buffer += ctypes.string_at(wav, numsamples * ctypes.sizeof(ctypes.c_short))
         return 0
+    
+    def endLoop(self):
+        self._looping = False
+    
+    def startLoop(self):
+        first = True
+        self._looping = True
+        while self._looping:
+            if not self._looping:
+                break
+            if first:
+                self._proxy.setBusy(False)
+                first = False
+                if self._text_to_say:
+                    self._start_synthesis(self._text_to_say)
+            self.iterate()
+            time.sleep(0.01)
+    
+    def iterate(self):
+        if not self._looping:
+            return
+        if self._stopping:
+            _espeak.Cancel()
+            self._stopping = False
+            self._proxy.notify('finished-utterance', completed=False)
+            self._proxy.setBusy(False)
+            self.endLoop()
+
+
+
+    def say(self, text):
+        self._text_to_say = text

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -183,6 +183,7 @@ class EspeakDriver(object):
                     elif platform.system() == 'Linux':
                         os.system(f'aplay {stream.name} -q')
                     elif platform.system() == 'Windows':
+                        print(f"Playing sound on Windows... {stream.name}")
                         winsound.PlaySound(stream.name, winsound.SND_FILENAME)
                     else:
                         raise RuntimeError("Unsupported operating system for audio playback")

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -68,8 +68,13 @@ class EspeakDriver(object):
             for v in _espeak.ListVoices(None):
                 kwargs = {'id': fromUtf8(v.name), 'name': fromUtf8(v.name)}
                 if v.languages:
-                    kwargs['languages'] = [v.languages]
-                genders = [None, 'male', 'female']
+                    try:
+                        language_code_bytes = v.languages[1:]
+                        language_code = language_code_bytes.decode('utf-8', errors='ignore')
+                        kwargs['languages'] = [language_code]
+                    except UnicodeDecodeError as e:
+                        kwargs['languages'] = ["Unknown"]
+                    genders = [None, 'male', 'female']
                 kwargs['gender'] = genders[v.gender]
                 kwargs['age'] = v.age or None
                 voices.append(Voice(**kwargs))

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -146,7 +146,16 @@ class EspeakDriver(object):
             if event.type == _espeak.EVENT_LIST_TERMINATED:
                 break
             if event.type == _espeak.EVENT_WORD:
-                self._proxy.notify('started-word', location=event.text_position, length=event.length)
+                
+                if self._text_to_say:
+                    start_index = event.text_position-1
+                    end_index = start_index + event.length
+                    word = self._text_to_say[start_index:end_index]
+                else:
+                    word = "Unknown"
+
+                self._proxy.notify('started-word', name=word, location=event.text_position, length=event.length)
+
             elif event.type == _espeak.EVENT_END:
                 stream = NamedTemporaryFile(delete=False, suffix='.wav')
     

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -152,6 +152,7 @@ class NSSpeechDriver(NSObject):
             success = True
         self._proxy.notify('finished-utterance', completed=success)
         self._proxy.setBusy(False)
+        self.endLoop()
 
     def speechSynthesizer_willSpeakWord_ofString_(self, tts, rng, text):
         self._proxy.notify('started-word', location=rng.location,

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -100,8 +100,8 @@ class NSSpeechDriver(NSObject):
     @objc.python_method
     def _toVoice(self, attr):
         return Voice(attr.get('VoiceIdentifier'), attr.get('VoiceName'),
-                 [attr.get('VoiceLocaleIdentifier', attr.get('VoiceLanguage'))], attr.get('VoiceGender'),
-                 attr.get('VoiceAge', None))
+                     [attr.get('VoiceLocaleIdentifier', attr.get('VoiceLanguage'))], attr.get('VoiceGender'),
+                     attr.get('VoiceAge'))
 
     @objc.python_method
     def getProperty(self, name):

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -100,8 +100,8 @@ class NSSpeechDriver(NSObject):
     @objc.python_method
     def _toVoice(self, attr):
         return Voice(attr.get('VoiceIdentifier'), attr.get('VoiceName'),
-                     [attr.get('VoiceLocaleIdentifier', attr.get('VoiceLanguage'))], attr.get('VoiceGender'),
-                     attr.get('VoiceAge'))
+                 [attr.get('VoiceLocaleIdentifier', attr.get('VoiceLanguage'))], attr.get('VoiceGender'),
+                 attr.get('VoiceAge', None))
 
     @objc.python_method
     def getProperty(self, name):

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -172,6 +172,7 @@ class SAPI5DriverEventSink(object):
         d._speaking = False
         d._stopping = False
         d._proxy.setBusy(False)
+        d.endLoop() # hangs if you dont have this
         
     def _ISpeechVoiceEvents_Word(self, stream_number, stream_position, char, length):
         self._driver._proxy.notify(

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -175,5 +175,4 @@ class SAPI5DriverEventSink(object):
         
     def _ISpeechVoiceEvents_Word(self, stream_number, stream_position, char, length):
         self._driver._proxy.notify(
-            'started-word', location=char, length=length
-       )
+            'started-word', location=char, length=length)

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -64,7 +64,7 @@ class SAPI5Driver(object):
         # call this async otherwise this blocks the callbacks
         # see SpeechVoiceSpeakFlags: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms720892%28v%3dvs.85%29
         # and Speak : https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms723609(v=vs.85)
-        self._tts.Speak(fromUtf8(toUtf8(text)), 1) # -> stream_number as described in the remarks of the documentation
+        self._tts.Speak(fromUtf8(toUtf8(text)), 1)  # -> stream_number as described in the remarks of the documentation
 
     def stop(self):
         if not self._speaking:
@@ -175,4 +175,5 @@ class SAPI5DriverEventSink(object):
         
     def _ISpeechVoiceEvents_Word(self, stream_number, stream_position, char, length):
         self._driver._proxy.notify(
-            'started-word', location=char, length=length)
+            'started-word', location=char, length=length
+)

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -176,4 +176,4 @@ class SAPI5DriverEventSink(object):
     def _ISpeechVoiceEvents_Word(self, stream_number, stream_position, char, length):
         self._driver._proxy.notify(
             'started-word', location=char, length=length
-)
+       )

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -61,7 +61,10 @@ class SAPI5Driver(object):
         self._proxy.setBusy(True)
         self._proxy.notify('started-utterance')
         self._speaking = True
-        self._tts.Speak(fromUtf8(toUtf8(text)))
+        # call this async otherwise this blocks the callbacks
+        # see SpeechVoiceSpeakFlags: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms720892%28v%3dvs.85%29
+        # and Speak : https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms723609(v=vs.85)
+        self._tts.Speak(fromUtf8(toUtf8(text)), 1) # -> stream_number as described in the remarks of the documentation
 
     def stop(self):
         if not self._speaking:
@@ -158,14 +161,18 @@ class SAPI5DriverEventSink(object):
     def setDriver(self, driver):
         self._driver = driver
 
-    def _ISpeechVoiceEvents_StartStream(self, char, length):
+    def _ISpeechVoiceEvents_StartStream(self, stream_number, stream_position):
         self._driver._proxy.notify(
-            'started-word', location=char, length=length)
+            'started-word', location=stream_number, length=stream_position)
 
-    def _ISpeechVoiceEvents_EndStream(self, stream, pos):
+    def _ISpeechVoiceEvents_EndStream(self, stream_number, stream_position):
         d = self._driver
         if d._speaking:
             d._proxy.notify('finished-utterance', completed=not d._stopping)
         d._speaking = False
         d._stopping = False
         d._proxy.setBusy(False)
+        
+    def _ISpeechVoiceEvents_Word(self, stream_number, stream_position, char, length):
+        self._driver._proxy.notify(
+            'started-word', location=char, length=length)


### PR DESCRIPTION
- Adding full support for runAndWait for eSpeak on Windows and Mac. **Linux untested fully - I can see word timings work but cant test audio output)** #4 
- Altered docs print lines for py3 for #5


~eSpeak does have one remaining issue. WordEvents are emitted but they occur BEFORE the words are spoken aloud.~ (fixed here)

Please check my code. I've had a lot of debug code in my work which I *think* I have stripped out 